### PR TITLE
Fix Call to a member function addEvent() on bool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,17 @@
 {
-  "name": "marcelog/pami",
+  "name": "level23/pami",
   "type": "library",
   "description": "Asterisk Manager Interface (AMI) client for PHP, event driven, object oriented",
   "keywords": ["asterisk","ami","client","telephony","voip","event","action","manager","monitor"],
   "homepage": "http://marcelog.github.com/PAMI",
   "license": "Apache-2.0",
   "authors": [
+    {
+      "name": "Richard Stellingwerff",
+      "email": "richard@level23.nl",
+      "homepage": "http://level23.github.com/",
+      "role": "Maintainer"
+    },
     {
       "name": "Marcelo Gornstein",
       "email": "marcelog@gmail.com",
@@ -19,7 +25,7 @@
     }
   },
   "require": {
-    "php": ">=5.3.3",
+    "php": ">=7.4",
     "psr/log": ">= 1.0.0"
   },
   "require-dev": {

--- a/src/PAMI/Client/Impl/ClientImpl.php
+++ b/src/PAMI/Client/Impl/ClientImpl.php
@@ -289,7 +289,12 @@ class ClientImpl implements IClient
                 $bMsg .= 'ActionId: ' . $this->lastActionId . "\r\n" . $aMsg;
                 $event = $this->messageToEvent($bMsg);
                 $response = $this->findResponse($event);
-                $response->addEvent($event);
+
+                if ($response) {
+                    $response->addEvent($event);
+                } else {
+                    $this->logger->debug('Unable to find an associated response for the given message.');
+                }
             }
             $this->logger->debug('----------------');
         }
@@ -300,15 +305,15 @@ class ClientImpl implements IClient
      *
      * @param IncomingMessage $message Message sent by asterisk.
      *
-     * @return \PAMI\Message\Response\ResponseMessage
+     * @return \PAMI\Message\Response\ResponseMessage|null
      */
-    protected function findResponse(IncomingMessage $message)
+    protected function findResponse(IncomingMessage $message): ?ResponseMessage
     {
         $actionId = $message->getActionId();
         if (isset($this->incomingQueue[$actionId])) {
             return $this->incomingQueue[$actionId];
         }
-        return false;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Ignore the event when findResponse() returns null